### PR TITLE
Ensure a new test suite passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+!/tmp/.gitkeep
 /rack_stuff


### PR DESCRIPTION
`rake` in a freshly-cloned directory was crashing because the `tmp` directory didn't exist.

Now the `tmp` directory is part of the Git repo and will be there even for freshly-cloned repositoriees.