### PR TITLE
Use `instance_eval` instead of `eval`

### DIFF
--- a/spec/mironfile_spec.rb
+++ b/spec/mironfile_spec.rb
@@ -31,14 +31,12 @@ describe Miron::Mironfile do
 
       it 'returns an instance of app' do
         mironfile = Miron::Mironfile.from_file(SpecHelper.temporary_directory + 'Mironfile1.rb')
-        expect(mironfile.app).to be_an_instance_of(HiThree)
-        expect(mironfile.app.class).to eq(HiThree)
+        expect(mironfile.app.class.to_s).to end_with 'HiThree'
       end
 
       it 'returns an instance of middleware' do
         mironfile = Miron::Mironfile.from_file(SpecHelper.temporary_directory + 'Mironfile1.rb')
-        expect(mironfile.middleware.first).to be_an_instance_of(HiFour)
-        expect(mironfile.middleware.first.class).to eq(HiFour)
+        expect(mironfile.middleware.first.class.to_s).to end_with 'HiFour'
       end
     end
 
@@ -49,14 +47,12 @@ describe Miron::Mironfile do
 
       it 'returns a class, not an instance of app' do
         mironfile = Miron::Mironfile.from_file(SpecHelper.temporary_directory + 'Mironfile.rb')
-        expect(mironfile.app).to_not be_an_instance_of(Hi)
-        expect(mironfile.app).to eq(Hi)
+        expect(mironfile.app.to_s).to end_with 'Hi'
       end
 
       it 'returns an class, not an instance of middleware' do
         mironfile = Miron::Mironfile.from_file(SpecHelper.temporary_directory + 'Mironfile.rb')
-        expect(mironfile.middleware.first).to_not be_an_instance_of(HiTwo)
-        expect(mironfile.middleware.first).to eq(HiTwo)
+        expect(mironfile.middleware.first.to_s).to end_with 'HiTwo'
       end
     end
   end


### PR DESCRIPTION
`eval` evaluates code in a global context (which required global `run` and `use` methods). `instance_eval` evaluates it in the context of an instance.

Previously, Mironfile took in a block that called `eval` on some Ruby code, then`instance_eval`-ed that block.

Now it takes the path to the file containing that Ruby code and calls `instance_eval` on the Ruby code directly, without ever calling `eval`. This means we can get rid of the global `run`/`use` methods.

This PR also removes the code that turned `Miron::Mironfile::CoolClass` into `CoolClass`, because it's now unnecessary (I think). With `instance_eval` it should all Just Work.