### PR TITLE
Use existing Mironfile.from_file method

### DIFF
--- a/lib/miron/mironfile.rb
+++ b/lib/miron/mironfile.rb
@@ -12,10 +12,7 @@ module Miron
 
     def self.from_dir(dir)
       path = dir + 'Mironfile.rb'
-      return nil unless path && File.exist?(path)
-      mironfile = Mironfile.new(path)
-      mironfile.evaluate
-      mironfile
+      from_file(path)
     end
 
     # Returns the contents of the Mironfile in the given path.
@@ -28,7 +25,7 @@ module Miron
     #
     def self.from_file(path)
       return nil unless path && File.exist?(path)
-      mironfile = Mironfile.new(path)
+      mironfile = new(path)
       mironfile.evaluate
       mironfile
     end


### PR DESCRIPTION
The code in `.from_dir` duplicated the `.from_file` code, so we can use the `.from_file` method instead.

Also, there's no need to reference `Mironfile` explicitly in the `Mironfile` class, so `Mironfile.new` can be `new`.